### PR TITLE
feat: wps225 check added

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/wemake_python_styleguide/WPS225.py
+++ b/crates/ruff_linter/resources/test/fixtures/wemake_python_styleguide/WPS225.py
@@ -1,0 +1,22 @@
+def f():
+    try:
+        pass
+    except RuntimeError:
+        pass
+    except Exception:
+        pass
+    except KeyboardInterrupt:
+        pass
+
+
+def g():
+    try:
+        pass
+    except RuntimeError:
+        pass
+    except Exception:
+        pass
+    except KeyboardInterrupt:
+        pass
+    except BaseException:
+        pass

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -1366,13 +1366,15 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
                 }
             }
         }
-        Stmt::Try(ast::StmtTry {
-            body,
-            handlers,
-            orelse,
-            finalbody,
-            ..
-        }) => {
+        Stmt::Try(
+            try_ @ ast::StmtTry {
+                body,
+                handlers,
+                orelse,
+                finalbody,
+                ..
+            },
+        ) => {
             if checker.enabled(Rule::TooManyNestedBlocks) {
                 pylint::rules::too_many_nested_blocks(checker, stmt);
             }
@@ -1438,6 +1440,11 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             }
             if checker.enabled(Rule::ErrorInsteadOfException) {
                 tryceratops::rules::error_instead_of_exception(checker, handlers);
+            }
+            if checker.enabled(Rule::TooManyExcepts) {
+                if let Some(diagnostic) = wemake_python_styleguide::too_many_excepts(try_) {
+                    checker.diagnostics.push(diagnostic)
+                }
             }
         }
         Stmt::Assign(assign @ ast::StmtAssign { targets, value, .. }) => {

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1055,6 +1055,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (WemakePythonStyleguide, "217") => (RuleGroup::Preview, rules::wemake_python_styleguide::TooManyAwaits),
         (WemakePythonStyleguide, "218") => (RuleGroup::Preview, rules::wemake_python_styleguide::TooManyAsserts),
         (WemakePythonStyleguide, "223") => (RuleGroup::Preview, rules::wemake_python_styleguide::TooManyElifs),
+        (WemakePythonStyleguide, "225") => (RuleGroup::Preview, rules::wemake_python_styleguide::TooManyExcepts),
         (WemakePythonStyleguide, "238") => (RuleGroup::Preview, rules::wemake_python_styleguide::TooManyRaises),
         _ => return None,
     })

--- a/crates/ruff_linter/src/rules/wemake_python_styleguide/many_excepts.rs
+++ b/crates/ruff_linter/src/rules/wemake_python_styleguide/many_excepts.rs
@@ -1,0 +1,33 @@
+use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::{ExceptHandler, StmtTry};
+
+const MAX_EXCEPTS: usize = 3;
+
+#[violation]
+pub struct TooManyExcepts(usize);
+
+impl Violation for TooManyExcepts {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!(
+            "Too many `except` statements: ({} > {})",
+            self.0, MAX_EXCEPTS
+        )
+    }
+}
+
+pub(crate) fn too_many_excepts(stmt: &StmtTry) -> Option<Diagnostic> {
+    stmt.handlers
+        .iter()
+        .skip(MAX_EXCEPTS)
+        .take(1)
+        .next()
+        .map(|handler| {
+            Diagnostic::new(TooManyExcepts(stmt.handlers.len()), {
+                match handler {
+                    ExceptHandler::ExceptHandler(handler) => handler.range,
+                }
+            })
+        })
+}

--- a/crates/ruff_linter/src/rules/wemake_python_styleguide/mod.rs
+++ b/crates/ruff_linter/src/rules/wemake_python_styleguide/mod.rs
@@ -4,9 +4,10 @@ pub(crate) use complexity::*;
 pub(crate) use many_class_methods::*;
 pub(crate) use many_decorators::*;
 pub(crate) use many_func_awaits::*;
-pub (crate) use many_asserts::*;
+pub(crate) use many_asserts::*;
 pub(crate) use many_elifs::*;
 pub(crate) use many_raises::*;
+pub(crate) use many_excepts::*;
 
 mod imports;
 mod definitions;
@@ -19,3 +20,4 @@ mod many_func_awaits;
 mod many_asserts;
 mod many_raises;
 mod many_elifs;
+mod many_excepts;


### PR DESCRIPTION
```python
rates/ruff_linter/resources/test/fixtures/wemake_python_styleguide/WPS225.py:21:5: WPS225 Too many `except` statements: (4 > 3)
   |
19 |       except KeyboardInterrupt:
20 |           pass
21 |       except BaseException:
   |  _____^
22 | |         pass
   | |____________^ WPS225
   |

Found 1 error.
```